### PR TITLE
made kuzzle worker spawn in a separate cluster

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -8,6 +8,6 @@ ADD /scripts /
 ADD /config/ /config/
 RUN chmod 755 /*.sh
 
-EXPOSE 8080
+EXPOSE 7512
 
 CMD ["/run.sh"]

--- a/dev/config/processes-dev.json
+++ b/dev/config/processes-dev.json
@@ -1,6 +1,19 @@
 {
-  "name": "Kuzzle",
-  "script": "app-start.js",
-  "watch": ["lib", "config", "bin"],
-  "ignore_watch" : ["node_modules"]
+  apps: [{                                                                                                                                                                                                                                                                                 
+      "name"         : "KuzzleServer",
+      "script"       : "app-start.js",
+      "args"         : ["--server"],
+      "watch"        : ["lib", "config", "bin"],
+      "ignore_watch" : ["node_modules"]
+    },
+    {                                                                                                                                                                                                                                                                                 
+      "name"         : "KuzzleWorker",
+      "script"       : "app-start.js",
+      "instances"    : 1,
+      "exec_mode"    : "cluster",
+      "args"         : ["--worker"],
+      "watch"        : ["lib", "config", "bin"],
+      "ignore_watch" : ["node_modules"]
+    }
+  ]
 }


### PR DESCRIPTION
For now I configured the docker image to spawn a single set of workers, scalable with "pm2 scale KuzzleWorker <number>".

Tried to spawn 3 sets of workers and, well... ElasticSearch hadn't enough CPU power to process our benchmark tests :-)