### PR TITLE
added specific version of nodejs

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,7 +7,6 @@ ENV ENV=/etc/profile
 RUN set -ex && \
     apk add -U \
         nmap \
-        nodejs \
         python && \
     npm install -g \
         pm2 \
@@ -17,6 +16,18 @@ RUN set -ex && \
     mkdir -p /var/app
 
 WORKDIR /var/app
+
+
+ENV NODE_VERSION=4.4.3
+
+ADD https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz /root/
+
+RUN mkdir /opt && \
+    gunzip /root/node-v$NODE_VERSION-linux-x64.tar.gz && \
+    tar xvf /root/node-v$NODE_VERSION-linux-x64.tar -C /opt/ && \
+    rm /root/node-v$NODE_VERSION-linux-x64.tar
+
+ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
 
 ADD /profile/profile /etc/profile
 ADD /profile/bash /bin/


### PR DESCRIPTION
The NodeJS version installed by `apk` is currently the 4.3.0 version.
Problem is: this version is unstable in debug mode due to this bug: https://github.com/nodejs/node/issues/4382

To solve this problem, this pull request removes `nodejs` from the list of installed package, and instead install it manually. This allows us to choose the NodeJS version to install, in our case, we install node v4.4.3, the latest v4 stable version.