### PR TITLE
Install full wget Alpine package into test container image

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -4,4 +4,5 @@ MAINTAINER Kuzzle <support@kuzzle.io>
 RUN apk add -U \
         build-base \
         git \
-        python 
+        python \
+        wget


### PR DESCRIPTION
To generate coverage for feature tests with cucumber and istanbul, we have to download a mirror of Kuzzle's coverage with wget (see https://github.com/gotwarlost/istanbul-middleware and https://github.com/kuzzleio/kuzzle/commit/c63a3dffca5beec67fc695c4e935b245ed9f9f39 to see how it works within Kuzzle).

This is done with following command:
```
wget -m -k -nH -E -P ' + coverageDestination + ' --cut-dirs=1 ' + config.url + '/coverage
```

But, since we have migrated Kuzzle containers to Alpine, this command is broken because the embed 'wget' command is a "lite" one that does support only limited options:
```
BusyBox v1.24.1 (2015-12-16 08:00:02 GMT) multi-call binary.
Usage: wget [-csq] [-O FILE] [-Y on/off] [-P DIR] [-U AGENT] [-T SEC] URL...
	Retrieve files via HTTP or FTP
	-s	Spider mode - only check file existence
	-c	Continue retrieval of aborted transfer
	-q	Quiet
	-P DIR	Save to DIR (default .)
	-T SEC	Network read timeout is SEC seconds
	-O FILE	Save to FILE ('-' for stdout)
	-U STR	Use STR for User-Agent header
	-Y	Use proxy ('on' or 'off')
```

This PR installs a full version of wget, from official Alpine package: http://pkgs.alpinelinux.org/package/v3.4/main/x86_64/wget
