### PR TITLE
adding curl to base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Kuzzle <support@kuzzle.io>
 RUN set -ex && \
     apk add -U \
         nmap \
+        curl \
         python && \
     npm install -g \
         pm2 \

--- a/bo-test/Dockerfile
+++ b/bo-test/Dockerfile
@@ -3,12 +3,10 @@ MAINTAINER Kuzzle <support@kuzzle.io>
 
 ADD /scripts /
 RUN set -ex && \
-    apk add -U \
-        curl && \
     chmod 755 /*.sh && \
     curl -Ls https://github.com/kuzzleio/kuzzle-containers/releases/download/dockerized-phantomjs-2.1.1/dockerized-phantomjs.tar.gz \
         | tar xz -C / && \
-    
+
     echo "done"
 
 ENV TERM=xterm-color

--- a/proxy-test/Dockerfile
+++ b/proxy-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM kuzzleio/lb-base:alpine
+FROM kuzzleio/proxy-base:alpine
 MAINTAINER Kuzzle <support@kuzzle.io>
 
 RUN apk add -U \


### PR DESCRIPTION
* Added curl to kuzzleio/base: it's required by bo-base and subsequent images, and it's also nice to have it available in other kuzzle images
* Removed curl installation from kuzzleio/bo-test image, since it's now installed in kuzzleio/base
* fixed kuzzleio/proxy-test parent image