### PR TITLE
No more progressbar on NPM

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -15,6 +15,8 @@ RUN set -ex && \
 
 WORKDIR /var/app
 
+RUN npm set progress=false
+
 ADD /profile/profile /etc/profile
 ADD /profile/bash /bin/
 ADD /scripts /

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,11 +11,10 @@ RUN set -ex && \
         grunt-cli@0.1.13 && \
     apk del --purge \
         python && \
-    mkdir -p /var/app
+    mkdir -p /var/app && \
+    npm set progress=false
 
 WORKDIR /var/app
-
-RUN npm set progress=false
 
 ADD /profile/profile /etc/profile
 ADD /profile/bash /bin/


### PR DESCRIPTION
This is meant to speed up npm installs (specially since Travis doesn't show the bar effectively) follows npm/npm#11283