### PR TITLE
Enable Selenium on the BO test image

### DIFF
--- a/bo-test/Dockerfile
+++ b/bo-test/Dockerfile
@@ -6,7 +6,8 @@ RUN set -ex && \
     chmod 755 /*.sh && \
     curl -Ls https://github.com/kuzzleio/kuzzle-containers/releases/download/dockerized-phantomjs-2.1.1/dockerized-phantomjs.tar.gz \
         | tar xz -C / && \
-
+    apk add --no-cache openjdk8-jre dbus firefox xvfb && \
+    dbus-uuidgen > /var/lib/dbus/machine-id && \
     echo "done"
 
 ENV TERM=xterm-color


### PR DESCRIPTION
This PR enables to execute hedaless Firefox on Alpine and execute tests via Nightwatch -> Selenium.
Nightwatch also works with Phantomjs, just in case.