### PR TITLE
install npm5 instead of npm3

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,3 +13,4 @@ RUN  set -x \
   && rm /tmp/node-v$NODE_VERSION-linux-x64.tar.gz \
   && mkdir -p /var/app \
   && npm install -g npm@5.6.0
+  && npm set progress=false

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch-slim
 
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 
-ENV NODE_VERSION=6.11.0
+ENV NODE_VERSION=6.13.1
 ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
 
 ADD https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz /tmp/
@@ -12,4 +12,4 @@ RUN  set -x \
   && tar xf /tmp/node-v$NODE_VERSION-linux-x64.tar.gz -C /opt/ \
   && rm /tmp/node-v$NODE_VERSION-linux-x64.tar.gz \
   && mkdir -p /var/app \
-  && npm set progress=false
+  && npm install -g npm@5.6.0

--- a/base/README.md
+++ b/base/README.md
@@ -2,4 +2,4 @@
 
 This repository contains Dockerfile for building [Kuzzle](https://github.com/kuzzleio/kuzzle) stack base image.
 
-Contains nodejs (6.11.0) binary and pm2 global module
+Contains nodejs (6.13.1), npm 5.6.0 and pm2 

--- a/base/README.md
+++ b/base/README.md
@@ -1,5 +1,5 @@
 # kuzzleio/base
 
-This repository contains Dockerfile for building [Kuzzle](https://github.com/kuzzleio/kuzzle) stack base image.
+[Kuzzle](https://github.com/kuzzleio/kuzzle) stack base image.
 
-Contains nodejs (6.13.1), npm 5.6.0 and pm2 
+Contains nodejs (6.13.1) and npm 5.6.0 


### PR DESCRIPTION
This allows using `package-lock.json` files, speeding up modules installations