### PR TITLE
Add containers with NodeJs 8.11.1

### DIFF
--- a/base8/Dockerfile
+++ b/base8/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:stretch-slim
+
+LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
+
+ENV NODE_VERSION=8.11.1
+ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
+
+ADD https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz /tmp/
+
+RUN  set -x \
+  \
+  && tar xf /tmp/node-v$NODE_VERSION-linux-x64.tar.gz -C /opt/ \
+  && rm /tmp/node-v$NODE_VERSION-linux-x64.tar.gz \
+  && mkdir -p /var/app \
+  && npm install -g npm@5.6.0 \
+  && npm set progress=false

--- a/base8/README.md
+++ b/base8/README.md
@@ -1,5 +1,5 @@
-# kuzzleio/base
+# kuzzleio/base8
 
-[Kuzzle](https://github.com/kuzzleio/kuzzle) stack base image.
+[Kuzzle](https://github.com/kuzzleio/kuzzle) stack base image with NodeJS 8.
 
-Contains nodejs (6.13.1) and npm 5.6.0 
+Contains nodejs (8.11.1) and npm 5.6.0

--- a/base8/README.md
+++ b/base8/README.md
@@ -1,0 +1,5 @@
+# kuzzleio/base
+
+[Kuzzle](https://github.com/kuzzleio/kuzzle) stack base image.
+
+Contains nodejs (6.13.1) and npm 5.6.0 

--- a/dev8/Dockerfile
+++ b/dev8/Dockerfile
@@ -1,0 +1,30 @@
+FROM kuzzleio/base8
+
+LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
+
+WORKDIR /var/app
+ENV TERM=xterm
+
+RUN set -x \
+ \
+ && apt-get update && apt-get install -y \
+      bash-completion \
+      build-essential \
+      curl \
+      g++ \
+      gdb \
+      git \
+      libfontconfig \
+      python \
+      rbenv \
+      wget \
+  && gem install \
+    sass --version 3.2.10 \
+  && npm install -g \
+    bower \
+    pm2@2.5.0 \
+  && echo "" > /opt/node-v$NODE_VERSION-linux-x64/lib/node_modules/pm2/lib/keymetrics \
+  \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && echo "alias ll=\"ls -lahF --color\"" >> ~/.bashrc

--- a/dev8/README.md
+++ b/dev8/README.md
@@ -1,0 +1,19 @@
+# kuzzleio/dev
+
+This repository contains Dockerfile for building [Kuzzle](https://github.com/kuzzleio/kuzzle) stack development image.
+
+Contains:
+ * all needed to watch and build kuzzleio projects on the fly:
+  * build-essential
+  * g++
+  * python
+  * rbenv
+  * libfontconfig
+  * [gem] sass
+  * [npm] bower
+  * [npm] node-inspector
+ * tools to improve development experience:
+  * bash-completion
+  * ll alias
+  * curl
+  * wget

--- a/dev8/README.md
+++ b/dev8/README.md
@@ -1,6 +1,6 @@
-# kuzzleio/dev
+# kuzzleio/dev8
 
-This repository contains Dockerfile for building [Kuzzle](https://github.com/kuzzleio/kuzzle) stack development image.
+This repository contains Dockerfile for building [Kuzzle](https://github.com/kuzzleio/kuzzle) stack development image with NodeJS 8.
 
 Contains:
  * all needed to watch and build kuzzleio projects on the fly:


### PR DESCRIPTION
## What does this PR do ?

This PR add two new containers with nodejs 8.11.1.  
I just changed the `NODE_VERSION` env variable in the base container.  
The new containers are `kuzzleio/base8` and `kuzzleio/dev8`.

### How should this be manually tested?

#### Test nodejs version

  - Step 1 : Build container `docker build -t kuzzleio/base8 base8/`
  - Step 2 : Check node version `docker run --rm kuzzleio/base8 node --version`
  - Step 3 :  Repeat with `dev8/`

#### Check DockerHub auto build
  - Step 1 : Check config here https://hub.docker.com/r/kuzzleio/base8/~/settings/automated-builds/
  - Step 2 : Check config here https://hub.docker.com/r/kuzzleio/dev8/~/settings/automated-builds/