### PR TITLE
Build multiple containers with different Node LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It contains :
 
 Contains nodejs (6.11.0) binary and pm2 global module
 
+
 ## kuzzleio/dev
 
 Based on kuzzleio/base

--- a/base6/Dockerfile
+++ b/base6/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:stretch-slim
+
+LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
+
+ENV NODE_VERSION=6.14.2
+ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
+
+ADD https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz /tmp/
+
+RUN  set -x \
+  \
+  && tar xf /tmp/node-v$NODE_VERSION-linux-x64.tar.gz -C /opt/ \
+  && rm /tmp/node-v$NODE_VERSION-linux-x64.tar.gz \
+  && mkdir -p /var/app \
+  && npm install -g npm@5.6.0 \
+  && npm set progress=false

--- a/base6/README.md
+++ b/base6/README.md
@@ -1,0 +1,5 @@
+# kuzzleio/base
+
+[Kuzzle](https://github.com/kuzzleio/kuzzle) stack base image.
+
+Contains nodejs (6.13.1) and npm 5.6.0 

--- a/dev6/Dockerfile
+++ b/dev6/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:stretch-slim
+
+LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
+
+ENV NODE_VERSION=6.9.0
+ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
+
+ADD https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz /tmp/
+
+RUN  set -x \
+  \
+  && tar xf /tmp/node-v$NODE_VERSION-linux-x64.tar.gz -C /opt/ \
+  && rm /tmp/node-v$NODE_VERSION-linux-x64.tar.gz \
+  && mkdir -p /var/app \
+  && npm install -g npm@5.6.0 \
+  && npm set progress=false
+
+WORKDIR /var/app
+ENV TERM=xterm
+
+RUN set -x \
+ \
+ && apt-get update && apt-get install -y \
+      bash-completion \
+      build-essential \
+      curl \
+      g++ \
+      gdb \
+      git \
+      libfontconfig \
+      python \
+      rbenv \
+      wget \
+  && gem install \
+    sass --version 3.2.10 \
+  && npm install -g \
+    bower \
+    pm2@2.5.0 \
+  && echo "" > /opt/node-v$NODE_VERSION-linux-x64/lib/node_modules/pm2/lib/keymetrics \
+  \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && echo "alias ll=\"ls -lahF --color\"" >> ~/.bashrc

--- a/dev6/README.md
+++ b/dev6/README.md
@@ -1,0 +1,19 @@
+# kuzzleio/dev
+
+This repository contains Dockerfile for building [Kuzzle](https://github.com/kuzzleio/kuzzle) stack development image.
+
+Contains:
+ * all needed to watch and build kuzzleio projects on the fly:
+  * build-essential
+  * g++
+  * python
+  * rbenv
+  * libfontconfig
+  * [gem] sass
+  * [npm] bower
+  * [npm] node-inspector
+ * tools to improve development experience:
+  * bash-completion
+  * ll alias
+  * curl
+  * wget


### PR DESCRIPTION
## What does this PR do ?

This PR is an open discussion and a POC to provide containers with multiple node LTS versions.  
The goal is to support the current node LTS version in our `kuzzleio/base` and `kuzzleio/dev` containers, be backward compatible with the previous LTS and start testing Kuzzle with the upcoming LTS.  

| Node LTS version | Kuzzle base image | Kuzzle dev image | Comment |
| :---                 |  :--- | :--- | :---: |
| `6.x.x` | `kuzzleio/base6` | `kuzzleio/dev6` | Backward compatibility |
| `8.x.x` | `kuzzleio/base` | `kuzzleio/dev` | Current | 
| `10.x.x` | `kuzzleio/base10` | `kuzzleio/dev10` | Prepare upcoming version |

For each LTS version we will test Kuzzle against the smaller LTS version (eg: `6.9.0`) and trust Joyent to don't break compatibility with further versions (eg: `6.13.1`).  

The `kuzzleio/base` image will be based on the latest LTS version (eg: `6.13.1`) and suitable for production environment.

The `kuzzleio/dev` image will be based on the first LTS version (eg: `6.9.0`) and used for development and testing Kuzzle. 

### How should this be manually tested?


### Other changes


### Boyscout
