### PR TITLE
Use node 8 by default with core-dev image

### DIFF
--- a/core-dev/Dockerfile
+++ b/core-dev/Dockerfile
@@ -38,3 +38,5 @@ RUN set -x \
   && rm -rf /var/lib/apt/lists/* \
   && echo "alias ll=\"ls -lahF --color\"" >> ~/.bashrc \
   && chmod +x ~/.bashrc
+
+RUN n $NODE_8_VERSION


### PR DESCRIPTION
## What does this PR do ?

This PR modify the `core-dev` Dockerfile to use node 8 default.

### How should this be manually tested?

  - Step 1 : Build the image : `cd core-dev && docker build -t kuzzleio/core-dev`
  - Step 2 : Run the image : `docker run --rm -it kuzzleio/core-dev node --version`