### PR TITLE
Add libzmq to dev images

### DIFF
--- a/core-dev-aarch64/Dockerfile
+++ b/core-dev-aarch64/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x \
     ca-certificates \
     curl \
     git \
+    libzmq3-dev \
     python \
     xz-utils \
   \

--- a/core-dev-armhf/Dockerfile
+++ b/core-dev-armhf/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x \
     ca-certificates \
     curl \
     git \
+    libzmq3-dev \
     python \
     xz-utils \
   \

--- a/core-dev/Dockerfile
+++ b/core-dev/Dockerfile
@@ -22,6 +22,7 @@ RUN set -x \
       gdb \
       git \
       libfontconfig \
+      libzmq3-dev \
       python \
       wget \
       nodejs \


### PR DESCRIPTION
## What does this PR do ?

This PR adds `libzmq` library to base images. 
The lib is used by the cluster and the mqtt protocol.