### PR TITLE
Add kuzzleio/php-dev image

### DIFF
--- a/php-dev/5.6/Dockerfile
+++ b/php-dev/5.6/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:5.6-cli
+
+LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
+
+WORKDIR /var/app
+ENV TERM=xterm
+
+RUN set -x \
+  \
+  && apt-get update && apt-get install -y \
+        bash-completion \
+        curl \
+        git \
+        libfontconfig \
+        wget \
+        zip \
+        unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "alias ll=\"ls -lahF --color\"" >> ~/.bashrc

--- a/php-dev/7.3/Dockerfile
+++ b/php-dev/7.3/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7.3-cli
+
+LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
+
+WORKDIR /var/app
+ENV TERM=xterm
+
+RUN set -x \
+  \
+  && apt-get update && apt-get install -y \
+        bash-completion \
+        curl \
+        git \
+        libfontconfig \
+        wget \
+        zip \
+        unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "alias ll=\"ls -lahF --color\"" >> ~/.bashrc

--- a/php-dev/README.md
+++ b/php-dev/README.md
@@ -1,0 +1,8 @@
+# kuzzleio/php-dev
+
+This image is useful for php developer who want to use the SDK PHP.
+It includes all necessary dependencies to use the SDK.
+
+This image is available with php 7 and php 5:
+ - `kuzzleio/php-dev:7.3`
+ - `kuzzleio/php-dev:5.6`


### PR DESCRIPTION
## What does this PR do ?

Adds Dockerfile to build php-dev images.  
These images contain all necessary dependencies to work with the php SDK.  
There are 2 tags, one with PHP 7.3 and the other with PHP 5.6

`kuzzleio/php-dev:7.3`
`kuzzleio/php-dev:5.6`