### PR TITLE
Upgrade to NPM 6 and use "npm ci" when appropriate

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,5 +12,5 @@ RUN  set -x \
   && tar xf /tmp/node-v$NODE_VERSION-linux-x64.tar.gz -C /opt/ \
   && rm /tmp/node-v$NODE_VERSION-linux-x64.tar.gz \
   && mkdir -p /var/app \
-  && npm install -g npm@5.6.0 \
+  && npm install -g npm@6.9.0 \
   && npm set progress=false

--- a/base/README.md
+++ b/base/README.md
@@ -2,4 +2,4 @@
 
 [Kuzzle](https://github.com/kuzzleio/kuzzle) stack base image.
 
-Contains nodejs (6.13.1) and npm 5.6.0 
+Contains nodejs (6.13.1) and npm 6.9.0

--- a/kuzzle-aarch64/Dockerfile
+++ b/kuzzle-aarch64/Dockerfile
@@ -40,10 +40,10 @@ RUN set -x \
   \
   \
   && git clone -b ${current_tag} --recursive https://github.com/kuzzleio/kuzzle.git . \
-  && npm install --unsafe-perm \
+  && npm ci --unsafe-perm \
   && for plugin in plugins/enabled/*/; do \
       cd $plugin; \
-      npm install --unsafe-perm; \  
+      npm ci --unsafe-perm; \
      done
   \
   && apt-get remove \

--- a/kuzzle-armhf/Dockerfile
+++ b/kuzzle-armhf/Dockerfile
@@ -40,10 +40,10 @@ RUN set -x \
   \
   \
   && git clone -b ${current_tag} --recursive https://github.com/kuzzleio/kuzzle.git . \
-  && npm install --unsafe-perm \
+  && npm ci --unsafe-perm \
   && for plugin in plugins/enabled/*/; do \
       cd $plugin; \
-      npm install --unsafe-perm; \  
+      npm ci --unsafe-perm; \
      done
   \
   && apt-get remove \


### PR DESCRIPTION
# Description

Preparative work allowing to update all our scripts&tools to make them use `npm ci` (added in npm@6) instead of `npm install`, which would be a bit more confortable when developing since this would prevent the `package-lock.json` file to be modified whenever a docker image is started.