### PR TITLE
[node] upgrade Node.js 6 to version 6.17.1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch-slim
 
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 
-ENV NODE_VERSION=6.13.1
+ENV NODE_VERSION=6.17.1
 ENV PATH=/opt/node-v$NODE_VERSION-linux-x64/bin:$PATH
 
 ADD https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz /tmp/

--- a/core-dev-armhf/Dockerfile
+++ b/core-dev-armhf/Dockerfile
@@ -3,7 +3,7 @@ FROM resin/armv7hf-debian:stretch
 LABEL io.kuzzle.vendor="Kuzzle <support@kuzzle.io>"
 LABEL description="Core development stack"
 
-ENV NODE_6_VERSION 6.13.1
+ENV NODE_6_VERSION 6.17.1
 ENV NODE_8_VERSION 8.11.3
 ENV NODE_10_VERSION=10.15.0
 ENV NODE_ENV=production

--- a/core-dev/Dockerfile
+++ b/core-dev/Dockerfile
@@ -5,7 +5,7 @@ LABEL description="Enhance the Kuzzle core with ease"
 
 WORKDIR /var/app
 ENV TERM=xterm
-ENV NODE_6_VERSION=6.13.1
+ENV NODE_6_VERSION=6.17.1
 ENV NODE_8_VERSION=8.11.3
 ENV NODE_10_VERSION=10.15.0
 


### PR DESCRIPTION
# Description 

The latest version of the `bufferutil` module cannot be installed on Node.js 6.13.1, but it works fine with 6.17.1.

Upgrading Node.js 6 to its latest version is required for this PR to work: https://github.com/kuzzleio/kuzzle/pull/1301