### PR TITLE
add node10 to core-dev images

### DIFF
--- a/core-dev-aarch64/Dockerfile
+++ b/core-dev-aarch64/Dockerfile
@@ -5,7 +5,7 @@ LABEL description="Core development stack"
 
 ENV NODE_6_VERSION 6.13.1
 ENV NODE_8_VERSION 8.11.3
-ENV NODE_10_VERSION=10.15.0
+ENV NODE_10_VERSION=10.16.0
 ENV NODE_ENV=production
 
 WORKDIR /var/app
@@ -48,12 +48,17 @@ RUN set -x \
   \
   && nvm install $NODE_6_VERSION  \
   && nvm use $NODE_6_VERSION \
-  && npm install -g --unsafe-perm \
-    pm2 \
+  && npm install -g --unsafe-perm pm2 \
+  \
   && nvm install $NODE_8_VERSION \
   && nvm use $NODE_8_VERSION \
-  && npm install -g --unsafe-perm \
-    pm2
+  && npm install -g --unsafe-perm pm2 \
+  \
+  && nvm install $NODE_10_VERSION \
+  && nvm use $NODE_10_VERSION \
+  && npm install -g --unsafe-perm pm2 \
+  \
+  && nvm use $NODE_8_VERSION
 
 
 RUN [ "cross-build-end" ]

--- a/core-dev-aarch64/Dockerfile
+++ b/core-dev-aarch64/Dockerfile
@@ -37,12 +37,12 @@ RUN set -x \
     i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_8_VERSION/node-v$NODE_8_VERSION-linux-$ARCH.tar.xz" \
-  && tar -xJf "node-v$NODE_8_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_8_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_10_VERSION/node-v$NODE_10_VERSION-linux-$ARCH.tar.xz" \
+  && tar -xJf "node-v$NODE_10_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_10_VERSION-linux-$ARCH.tar.xz" \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
   \
-  && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash \
+  && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash \
   && export NVM_DIR="$HOME/.nvm" \
   && . "$NVM_DIR/nvm.sh" \
   \

--- a/core-dev-armhf/Dockerfile
+++ b/core-dev-armhf/Dockerfile
@@ -37,12 +37,12 @@ RUN set -x \
     i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_8_VERSION/node-v$NODE_8_VERSION-linux-$ARCH.tar.xz" \
-  && tar -xJf "node-v$NODE_8_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_8_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_10_VERSION/node-v$NODE_10_VERSION-linux-$ARCH.tar.xz" \
+  && tar -xJf "node-v$NODE_10_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_10_VERSION-linux-$ARCH.tar.xz" \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
   \
-  && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash \
+  && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash \
   && export NVM_DIR="$HOME/.nvm" \
   && . "$NVM_DIR/nvm.sh" \
   \

--- a/core-dev-armhf/Dockerfile
+++ b/core-dev-armhf/Dockerfile
@@ -5,7 +5,7 @@ LABEL description="Core development stack"
 
 ENV NODE_6_VERSION 6.17.1
 ENV NODE_8_VERSION 8.11.3
-ENV NODE_10_VERSION=10.15.0
+ENV NODE_10_VERSION=10.16.0
 ENV NODE_ENV=production
 
 WORKDIR /var/app
@@ -48,12 +48,17 @@ RUN set -x \
   \
   && nvm install $NODE_6_VERSION  \
   && nvm use $NODE_6_VERSION \
-  && npm install -g --unsafe-perm \
-    pm2 \
+  && npm install -g --unsafe-perm pm2 \
+  \
   && nvm install $NODE_8_VERSION \
   && nvm use $NODE_8_VERSION \
-  && npm install -g --unsafe-perm \
-    pm2
+  && npm install -g --unsafe-perm pm2 \
+  \
+  && nvm install $NODE_10_VERSION \
+  && nvm use $NODE_10_VERSION  \
+  && npm install -g --unsafe-perm pm2 \
+  \
+  && nvm use $NODE_8_VERSION
 
 RUN [ "cross-build-end" ]
 

--- a/core-dev/Dockerfile
+++ b/core-dev/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x \
       python \
       procps \
       wget \
-  && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && apt-get install -y nodejs \
   \
   && npm install -g n \

--- a/core-dev/Dockerfile
+++ b/core-dev/Dockerfile
@@ -7,39 +7,41 @@ WORKDIR /var/app
 ENV TERM=xterm
 ENV NODE_6_VERSION=6.17.1
 ENV NODE_8_VERSION=8.11.3
-ENV NODE_10_VERSION=10.15.0
-
-RUN  apt-get update && apt-get install -y \
-        curl \
-        gnupg \
-  && curl -sL https://deb.nodesource.com/setup_8.x | bash -
+ENV NODE_10_VERSION=10.16.0
 
 RUN set -x \
  \
+ && apt-get update \
  && apt-get install -y \
       bash-completion \
       build-essential \
+      curl \
       g++ \
       gdb \
       git \
+      gnupg \
       libfontconfig \
       libzmq3-dev \
       python \
       procps \
       wget \
-      nodejs \
+  && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+  && apt-get install -y nodejs \
+  \
   && npm install -g n \
   \
-  && n $NODE_8_VERSION \
-  && npm install -g \
-    pm2 \
-  \
   && n $NODE_6_VERSION \
-  && npm install -g \
-    pm2 \
+  && npm install -g pm2 \
+  \
+  && n $NODE_8_VERSION \
+  && npm install -g pm2 \
+  \
+  && n $NODE_10_VERSION \
+  && npm install -g pm2 \
+  \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && echo "alias ll=\"ls -lahF --color\"" >> ~/.bashrc \
-  && chmod +x ~/.bashrc
-
-RUN n $NODE_8_VERSION
+  && chmod +x ~/.bashrc \
+  \
+  && n $NODE_8_VERSION


### PR DESCRIPTION
## What does this PR do ?

Add node.js 10.16.0 to core-dev* images.

### Other changes

Merge the `RUN` steps between node install and the rest to allow apt cache deletion.