### PR TITLE
Bumb node

### DIFF
--- a/core-dev/Dockerfile
+++ b/core-dev/Dockerfile
@@ -5,7 +5,8 @@ LABEL description="Enhance the Kuzzle core with ease"
 
 WORKDIR /var/app
 ENV TERM=xterm
-ENV NODE_12_VERSION=12.16.3
+ENV NODE_12_16_3=12.16.3
+ENV NODE_12_VERSION=12.18.1
 
 RUN set -x \
  \
@@ -28,8 +29,9 @@ RUN set -x \
   \
   && npm install -g n \
   \
+  && n $NODE_12_16_3 \
   && n $NODE_12_VERSION \
-  && npm install -g nodemon \
+  && npm install -g nodemon kourou \
   \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## What does this PR do ?

Bump Node to 12.18.1

This PR (https://github.com/kuzzleio/kuzzle/pull/1604) will include a feature which is available only from Node.js 18 so I want to keep a version of Node.js 16.x to run the functional tests and ensure that Kuzzle is running with both version to prevent breaking changes

(Good point from @alexandrebouthinon )